### PR TITLE
fixed package name

### DIFF
--- a/collection.go
+++ b/collection.go
@@ -1,4 +1,4 @@
-package service
+package collection
 
 import (
 	"sync"


### PR DESCRIPTION
This PR fixes the package name. It is now `collection` to match the repo name. 